### PR TITLE
Proper flow

### DIFF
--- a/lib/capistrano/lephare/defaults.rb
+++ b/lib/capistrano/lephare/defaults.rb
@@ -1,3 +1,6 @@
+# APC sleep (in second)
+set :apc_sleep, 5
+
 # Librato username
 set :librato_username,  false
 
@@ -15,9 +18,6 @@ set :htpasswd_whitelist, []
 
 # Tmp folder
 set :tmp_dir, "/tmp/#{fetch(:stage)}"
-
-# publish_assets
-set :publish_assets, ENV["PUBLISH_ASSETS"] || false
 
 # max db backups
 set :keep_db_backups, 5
@@ -45,7 +45,3 @@ after 'deploy:starting', 'composer:install_executable'
 after 'deploy:publishing', 'symfony:assets:install'
 after 'deploy:finishing', 'deploy:migrate'
 after 'deploy:finished', 'deploy:cleanup'
-
-if fetch(:publish_assets)
-    after 'deploy:publishing', 'deploy:publish_assets'
-end

--- a/lib/capistrano/tasks/apc.rake
+++ b/lib/capistrano/tasks/apc.rake
@@ -13,12 +13,13 @@ namespace :apc do
 
         run_locally do
           output = %x[curl -s -l http://#{fetch(:domain)}/apc_clear.php]
+          sleep = fetch(:apc_sleep)
 
           while output != fetch(:current_revision)
-            sleep(1)
+            sleep(sleep)
             output = %x[curl -s -l http://#{fetch(:domain)}/apc_clear.php]
 
-            debug 'Retry APC clear in 1 second.'
+            debug "Retry APC clear in #{sleep} second."
           end
 
           info 'Successfully cleared APC cache.'

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -1,7 +1,7 @@
 namespace :deploy do
 
   desc 'Deploy with assets'
-  task :assets do
+  task :with_assets do
     after 'deploy:publishing', 'deploy:publish_assets'
     invoke "deploy"
   end


### PR DESCRIPTION
- [x] The APC sleep is now configurable (default to 5s)
- [x] New `deploy:with_assets` task. 
- [x] `deploy:publish_assets` does not rely on environment variable anymore
