### PR TITLE
Improve crontab task

### DIFF
--- a/lib/capistrano/tasks/crontab.rake
+++ b/lib/capistrano/tasks/crontab.rake
@@ -1,15 +1,42 @@
 namespace :crontab do
-  desc <<-DESC
-    Update the crontab
-  DESC
-  task :update do
-    on roles(:web) do
-      if test("[ -f #{fetch(:crontab_file)} ]")
-        info "Update crontab with #{fetch(:crontab_file)}"
-        execute "crontab #{fetch(:crontab_file)}"
-      else
-        info "No crontab found at #{fetch(:crontab_file)}"
+
+  desc "Lists tasks in user crontab"
+  task :list do
+    on roles(:app) do
+      info "Lists tasks in '#{fetch(:stage)}' stage"
+      capture(:crontab, "-l", "2>&1", "||", "true").each_line do |line|
+        puts line
       end
     end
   end
+
+  desc "Update user crontab"
+  task :update do
+    on roles(:app) do
+
+      crontab_file = fetch(:crontab_file)
+
+      if test("[ -f #{release_path}/#{crontab_file}.#{fetch(:stage)} ]")
+        crontab_file = "#{crontab_file}.#{fetch(:stage)}"
+      end
+
+      if test("[ -f #{release_path}/#{crontab_file} ]")
+        info "Update crontab with #{crontab_file}"
+        execute :crontab, "#{release_path}/#{crontab_file}"
+      else
+        info "No crontab found at #{crontab_file}"
+      end
+    end
+  end
+
+  desc "Delete user crontab"
+  task :delete do
+    on roles(:app) do
+      info "Delete tasks in '#{fetch(:stage)}' stage"
+      capture(:crontab, "-r", "2>&1", "||", "true").each_line do |line|
+        puts line
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
- Add `crontab:list`   to lists installed crontab task on stage
- Add `crontab:delete` to remove all tasks from crontab
- Update `crontab:update` to handle stage-suffixed crontab

Example:

  if a file `app/Resource/crontab.staging` exists
  `cap staging crontab:update` will use this file instead of the
  regular one.