### PR TITLE
Pull shared files

### DIFF
--- a/lib/capistrano/lephare.rb
+++ b/lib/capistrano/lephare.rb
@@ -8,6 +8,7 @@ load File.expand_path("../tasks/deploy.rake", __FILE__)
 load File.expand_path("../tasks/ssh.rake", __FILE__)
 load File.expand_path("../tasks/oceanet.rake", __FILE__)
 load File.expand_path("../tasks/log.rake", __FILE__)
+load File.expand_path("../tasks/shared.rake", __FILE__)
 
 namespace :load do
   task :defaults do

--- a/lib/capistrano/tasks/shared.rake
+++ b/lib/capistrano/tasks/shared.rake
@@ -3,8 +3,9 @@
 #
 # Configuration:
 #
-# - `shared_rsync_options`: Allow to specify which options to be used to pull rsync (default: `-avz --no-owner --no-group -delete`)
-# - `shared_sync_pattern`:  Allow to filter directories path using regular expression (default: `/^(web\/medias|app\/Resources)/`)
+# - `shared_rsync_options`:    Allow to specify which options to be used to pull rsync (default: `-avz --no-owner --no-group -delete`)
+# - `shared_sync_pattern`:     Allow to filter directories path using regular expression (default: `/^(web\/medias|app\/Resources)/`)
+# - `shared_exclude_paths`:    Allow to exclude paths using rsync exclude patterns (default: [web/medias/.tmb])
 #
 namespace :shared do
   desc "Pull locally shared files using rsync"
@@ -12,9 +13,14 @@ namespace :shared do
     on roles(:app) do |server|
       run_locally do
         rsync_options = fetch(:shared_rsync_options, "-avz --no-owner --no-group -delete")
+        rsync_exclude = ''
+        shared_exclude_paths = fetch(:shared_exclude_paths, ['web/medias/.tmb'])
+        shared_exclude_paths.each do |path|
+          rsync_exclude += " --exclude '#{shared_path}/#{path}/*'"
+        end
         fetch(:linked_dirs).each do |dir|
-          if dir =~ fetch(:shared_rsync_pattern, /^(web\/medias|app\/Resources)/)
-            execute :rsync, rsync_options, "-e 'ssh -p #{fetch(:port, 22)}'", "#{server.user}@#{server.hostname}:#{shared_path}/#{dir}/*", "#{dir}"
+          if dir =~ fetch(:shared_rsync_pattern, /^(web\/medias|app\/Resources)/) and not shared_exclude_paths.include?(dir)
+            execute :rsync, rsync_options, rsync_exclude, "-e 'ssh -p #{fetch(:port, 22)}'", "#{server.user}@#{server.hostname}:#{shared_path}/#{dir}/*", "#{dir}"
           end
         end
       end

--- a/lib/capistrano/tasks/shared.rake
+++ b/lib/capistrano/tasks/shared.rake
@@ -1,3 +1,11 @@
+#
+# Manage shared files
+#
+# Configuration:
+#
+# - `shared_rsync_options`: Allow to specify which options to be used to pull rsync (default: `-avz --no-owner --no-group -delete`)
+# - `shared_sync_pattern`:  Allow to filter directories path using regular expression (default: `/^(web\/medias|app\/Resources)/`)
+#
 namespace :shared do
   desc "Pull locally shared files using rsync"
   task :pull do
@@ -5,7 +13,7 @@ namespace :shared do
       run_locally do
         rsync_options = fetch(:shared_rsync_options, "-avz --no-owner --no-group -delete")
         fetch(:linked_dirs).each do |dir|
-          if dir =~ fetch(:shared_rsync_pattern, /^(web|app\/Resources)/)
+          if dir =~ fetch(:shared_rsync_pattern, /^(web\/medias|app\/Resources)/)
             execute :rsync, rsync_options, "-e 'ssh -p #{fetch(:port, 22)}'", "#{server.user}@#{server.hostname}:#{shared_path}/#{dir}/*", "#{dir}"
           end
         end

--- a/lib/capistrano/tasks/shared.rake
+++ b/lib/capistrano/tasks/shared.rake
@@ -1,0 +1,15 @@
+namespace :shared do
+  desc "Pull locally shared files using rsync"
+  task :pull do
+    on roles(:app) do |server|
+      run_locally do
+        rsync_options = fetch(:shared_rsync_options, "-avz --no-owner --no-group -delete")
+        fetch(:linked_dirs).each do |dir|
+          if dir =~ fetch(:shared_rsync_pattern, /^(web|app\/Resources)/)
+            execute :rsync, rsync_options, "-e 'ssh -p #{fetch(:port, 22)}'", "#{server.user}@#{server.hostname}:#{shared_path}/#{dir}/*", "#{dir}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Manage shared files
## Configuration:

 - `shared_rsync_options`: Allow to specify which options to be used to pull rsync (default: `-avz --no-owner --no-group -delete`)
 - `shared_sync_pattern`:  Allow to filter directories path using regular expression (default: `/^(web\/medias|app\/Resources)/`)
