### PR TITLE
FIX:  Arpane Reload

### DIFF
--- a/lib/capistrano/tasks/arpane.rake
+++ b/lib/capistrano/tasks/arpane.rake
@@ -2,7 +2,7 @@ namespace :arpane do
     namespace :php do
         task :reload do
             on roles(:web) do
-                execute "touch ~/restart_apache_to_clean_apc.txt"
+                execute "touch ~/restart_apache_to_clean_apc.txt && inotifywait --event delete --timeout 5 ~/restart_apache_to_clean_apc.txt"
             end
         end
     end

--- a/lib/capistrano/tasks/arpane.rake
+++ b/lib/capistrano/tasks/arpane.rake
@@ -2,7 +2,7 @@ namespace :arpane do
     namespace :php do
         task :reload do
             on roles(:web) do
-                execute "touch ~/restart_apache_to_clean_apc.txt && inotifywait --event delete --timeout 5 ~/restart_apache_to_clean_apc.txt"
+                execute "( touch ~/restart_apache_to_clean_apc.txt && inotifywait --event delete --timeout 5 ~/restart_apache_to_clean_apc.txt || [ $? -eq 1 ] )"
             end
         end
     end

--- a/lib/capistrano/tasks/arpane.rake
+++ b/lib/capistrano/tasks/arpane.rake
@@ -2,7 +2,7 @@ namespace :arpane do
     namespace :php do
         task :reload do
             on roles(:web) do
-                execute "( touch ~/restart_apache_to_clean_apc.txt && inotifywait --event delete --timeout 5 ~/restart_apache_to_clean_apc.txt || [ $? -eq 1 ] )"
+                execute "( touch #{shared_path}/restart_apache_to_clean_apc.txt && ( inotifywait --event delete --timeout 5 #{shared_path}/restart_apache_to_clean_apc.txt || [ $? -eq 1 ] ) )"
             end
         end
     end


### PR DESCRIPTION
Reload arpane server has fast as possible with inotify : 

Server side : 

1. Wait for the file to be created
2. Restart the given process
3. Delete the file
4. Log the restart
3. Loop 

```
while inotifywait -qe create /home/user1/shared/ > /dev/null; do
  if [ -f /home/user1/shared/restart_apache_to_clean_apc.txt ]; then 
    service apache2 restart;
    unlink /home/user1/shared/restart_apache_to_clean_apc.txt;
    echo -e "Apache redémarré après déploiement en production\n";
  fi
done
```

Client side :

1. Create a file
2. Wait for this file to be deleted (if it's not deleted with 5sec. command fails)

```
(
   touch ~/shared/restart_apache_to_clean_apc.txt && \ 
   ( inotifywait --event delete --timeout 5 ~/shared/restart_apache_to_clean_apc.txt  || [ $? -eq 1 ] )
)
```

