### PR TITLE
Server side assets compilation

### DIFF
--- a/lib/capistrano/tasks/npm.rake
+++ b/lib/capistrano/tasks/npm.rake
@@ -1,0 +1,21 @@
+namespace :npm do
+
+	desc 'Install node_modules'
+	task install: :'nvm:binaries' do
+		on roles(:app) do
+			within release_path do
+				execute :npm, 'install'
+			end
+		end
+	end
+
+	desc 'Run "build" script'
+	task build: :'nvm:binaries' do
+		on roles(:app) do
+			within release_path do
+				execute :npm, 'run', 'build'
+			end
+		end
+	end
+
+end

--- a/lib/capistrano/tasks/nvm.rake
+++ b/lib/capistrano/tasks/nvm.rake
@@ -1,0 +1,66 @@
+namespace :nvm do
+
+	desc 'Clone nvm repository'
+	task :install do
+		on release_roles(fetch(:nvm_roles)) do
+				execute :git , 'clone', 'https://github.com/creationix/nvm.git', fetch(:nvm_path)
+		end
+	end
+
+	desc 'Validate nvm install'
+	task :validate do
+		on release_roles(fetch(:nvm_roles)) do
+			if not test("[ -d .nvm ]")
+				Rake::Task["nvm:install"].invoke
+			end
+		end
+	end
+
+	desc 'Wrap binaries for SSHKit'
+	task binaries: :'nvm:wrapper' do
+		SSHKit.config.default_env.merge!({
+			node_version: "#{fetch(:nvm_node, 'stable')}",
+		})
+		nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh" } )
+		fetch(:nvm_map).each do |command|
+			SSHKit.config.command_map.prefix[command.to_sym].unshift(nvm_prefix)
+		end
+	end
+
+	desc 'Setup node and npm wrappers'
+	task wrapper: :'nvm:validate' do
+		on release_roles(fetch(:nvm_roles)) do
+
+			execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
+
+			upload! StringIO.new(<<-EOS), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+			#!/bin/bash -e
+			source #{fetch(:nvm_path)}/nvm.sh
+
+			nvm install $NODE_VERSION 2> /dev/null
+			nvm use --delete-prefix $NODE_VERSION
+
+			exec "$@"
+			EOS
+
+			execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+		end
+	end
+end
+
+namespace :load do
+	task :defaults do
+
+		set :nvm_path, -> {
+			nvm_path = fetch(:nvm_custom_path)
+			nvm_path ||= if fetch(:nvm_type, :user) == :system
+				"/usr/local/nvm"
+			else
+				"$HOME/.nvm"
+			end
+		}
+
+		set :nvm_roles, fetch(:nvm_roles, :all)
+		set :nvm_map, %w{node npm}
+	end
+end


### PR DESCRIPTION
- [x] Setup a given version of nodejs (default: stable)
- [x] Install dependencies
- [x] Run custom build task

## How to use 

In your stage (ie: app/config/capistrano/stages/preprod.rb) simply add something like : 

```ruby
after 'deploy:updated', 'npm:build'
```

Then update your package.json with some lifecycle scripts : 

```json
{
  "name": "project",
  "private": true,
  "scripts": {
    "postinstall" : "npm install -g gulp",
    "build": "gulp"
  },
  "devDependencies": {
    "gulp": "*",
    ...
  }
}
```

The actual workflow will run 

 `nvm:install` => `nvm:binaries` => `npm:install` => `npm:build`

## Configuration 

Variable        | Description                                          | Default 
---------------- | ----------------------------------------------- | -----------------------
`:nvm_node` | Node version to use                            | `stable`
`:nvm_roles` | defines the capistrano roles to run on | `:all`
`:nvm_map`  | wrap binaries for SSHKit                      | `%w{node npm}`



