### PR TITLE
Use officially supported rollbar

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{rb,rake}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The default capistrano workflow is used with the addition of theses tasks.
 Used to clear the APC cache at the end of the deployement. We recomend using it after after 'deploy:finishing'.
 
     after 'deploy:finishing', 'apc:cache:clear'
-  
-The task will put a `apc_clear_{revision}.php` file in the :webroot folder and call it via a local curl command. 
+
+The task will put a `apc_clear_{revision}.php` file in the :webroot folder and call it via a local curl command.
 The call is looped until it return the good revision.
 
 ### apc:monitor:enable
 
-Enable the apc monitor. 
+Enable the apc monitor.
 
 ### apc:monitor:disable
 
@@ -38,12 +38,12 @@ Update the crontab with `:crontab_file`. We recomend using it after after 'deplo
 
 ### mysql:backup
 
-Backup the remote database in `#{fetch(:deploy_to)}/backups`. We use mysqldump command with `:mysqldump_args`. 
+Backup the remote database in `#{fetch(:deploy_to)}/backups`. We use mysqldump command with `:mysqldump_args`.
 The command only keep  `:keep_db_backups` backups.
 
 ### mysql:pull
 
-Backup the remote database, download the backup in `:db_pull_filename` and restore it locally. 
+Backup the remote database, download the backup in `:db_pull_filename` and restore it locally.
 
 ### deploy:with_assets
 
@@ -55,7 +55,7 @@ Publish assets declared in `:assets_path` on remote server.
 
 ### deploy:migrate
 
-Launch symfony `doctrine:migration:migrate` command. 
+Launch symfony `doctrine:migration:migrate` command.
 
 ### deploy:no_robots
 
@@ -63,19 +63,13 @@ Put a robots.txt that disallow robot indexing
 
 ### deploy:secure
 
-Secure the application by putting a htpasswd authentification. 
+Secure the application by putting a htpasswd authentification.
 The credential are defined by `:htpasswd_user` and `:htpasswd_pwd` variables and you can whitelist IP with `:htpasswd_whitelist`.
 
 ### librato:annotate
 
 Push a librato annotation with `:librato_username` and `:librato_token`.
 
-### rollbar:notify
-
-Notify a deploy in rollbar with `:rollbar_token`.
-
 ## Options
 
 Look at [defaults.rb](lib/capistrano/lephare/defaults.rb) to view defaults values.
-  
-  

--- a/lib/capistrano/tasks/rollbar.rake
+++ b/lib/capistrano/tasks/rollbar.rake
@@ -1,6 +1,31 @@
 namespace :rollbar do
   task :notify do
     on roles(:app) do |h|
+      $stderr.puts(<<-MESSAGE)
+[Deprecation Notice] Use officialy supported rollbar plugin for capistrano
+
+See https://rollbar.com/docs/deploys/capistrano/
+
+Add to your Gemfile:
+
+    gem 'rollbar', '~1.2.7'
+
+Add to your Capfile:
+
+    require 'rollbar/capistrano3'
+
+Add to your deploy.rb:
+
+    set :rollbar_token, 'POST_SERVER_ITEM_ACCESS_TOKEN'
+    set :rollbar_env, Proc.new { fetch :stage }
+    set :rollbar_role, Proc.new { :app }
+
+Then remove from deploy.rb
+
+    after :finishing, "rollbar:notify"
+
+MESSAGE
+
       if fetch(:rollbar_token)
         revision = `git log -n 1 --pretty=format:"%H"`
         local_user = `whoami`.strip!

--- a/lib/capistrano/tasks/rollbar.rake
+++ b/lib/capistrano/tasks/rollbar.rake
@@ -8,7 +8,7 @@ See https://rollbar.com/docs/deploys/capistrano/
 
 Add to your Gemfile:
 
-    gem 'rollbar', '~1.2.7'
+    gem 'rollbar', '~>1.2.7'
 
 Add to your Capfile:
 


### PR DESCRIPTION
Rollbar supports capistrano for a moment now and we still use our own hook implementation. 

This PR is meant to be the first of a series of "cleanup" changes leading to releasing the 1.0.0 version of capistrano-lephare.

For now a deprecation notice is displayed at the end of deployment until you change your project configuration.