### PR TITLE
Fix tmp_dir when using multiple project on the same host

### DIFF
--- a/lib/capistrano/lephare/defaults.rb
+++ b/lib/capistrano/lephare/defaults.rb
@@ -15,7 +15,7 @@ set :htpasswd_whitelist, []
 set :webroot, -> { "#{release_path}/web" }
 
 # Tmp folder
-set :tmp_dir, "/tmp/#{fetch(:stage)}"
+set :tmp_dir, "/tmp/#{fetch(:application)}-#{fetch(:stage)}"
 
 # max db backups
 set :keep_db_backups, 5

--- a/lib/capistrano/lephare/defaults.rb
+++ b/lib/capistrano/lephare/defaults.rb
@@ -15,7 +15,7 @@ set :htpasswd_whitelist, []
 set :webroot, -> { "#{release_path}/web" }
 
 # Tmp folder
-set :tmp_dir, "/tmp/#{fetch(:application)}-#{fetch(:stage)}"
+set :tmp_dir,  -> { "/tmp/#{fetch(:application)}-#{fetch(:stage)}" }
 
 # max db backups
 set :keep_db_backups, 5


### PR DESCRIPTION
When multiple project are deployed on the same host the second project fail to deploy because the first temporary directory is owned by the first project owner. 

To fix that we must change the temporary directory one for a more precise one.

This PR fixes #26 